### PR TITLE
fix (and test) for case where events for today are not in suncalc's getTimes(today)

### DIFF
--- a/lib/sunevents.js
+++ b/lib/sunevents.js
@@ -59,24 +59,54 @@ class SunEvents extends EventEmitter {
         this.debug("Started job to calculate sunevents for tomorrow onwards", this.cronjob.nextDates().toJSON());
     }
 
+    getTimes(date, current) {
+        let now = moment(current)
+        let midDay = moment(date).startOf('day').add(12, 'hours')
+        let midnight = moment(date).startOf('day').add(24, 'hours')
+        let midDayTomorrow = moment(date).startOf('day').add(12+24, 'hours')
+        this.debug("Calculating times for %s", midDay)
+        
+        let times = SunCalc.getTimes(midDay, this.lat, this.lng)                
+        let timesTomorrow = SunCalc.getTimes(midDayTomorrow, this.lat, this.lng)                
+        let todayTimes = {}
+
+        for (let [event, datetimeToday, datetimeTomorrow] of Object.entries(times)
+            .map( ([k,v]) => [k, moment(v), moment(timesTomorrow[k])]) // wrap each datetime value in moment
+            .sort( (a, b) => a[1].diff(b[1]) ) // Sort the sunevents into time order to make debugging easier
+            ) {
+	    let datetime = datetimeToday
+            let hrs = datetime.diff(now, "hours") // Just used in ignore debug message
+            if(datetime.isAfter(now)) {
+                this.debug("Including %s, %s %s in %d hours", datetime.format(), event, datetime.calendar(date), hrs);
+	    } else {
+		if(datetimeTomorrow.isSameOrBefore(midnight)) {
+		  datetime = datetimeTomorrow
+		  hrs = datetime.diff(now, "hours") // Just used in ignore debug message
+		  this.debug("Including Tomorrow's %s, %s %s in %d hours", datetime.format(), event, datetime.calendar(date), hrs);
+	      } else {
+		  this.debug("Ignoring %s, %s was %s, %d hours ago", datetime.format(), event, datetime.calendar(), hrs);
+	      }
+	    }
+	    todayTimes[event] = datetime
+        }
+
+        this.debug("Times are", util.inspect(times))
+
+        return todayTimes
+    }
+
     setTimers(date) {
         let now = new moment()
-        let midDay = moment(date).startOf('day').add(12, 'hours')
         //this.timers = []
         
         if (this.testMode) {
             this.debug('****** Test Mode ******')
         }
-        this.debug("Calculating times for %s", midDay)
-        
-        let times = SunCalc.getTimes(midDay, this.lat, this.lng)                
 
-        this.debug("Times are", util.inspect(times))
-
+        let times = this.getTimes(date, now)
         let self = this
 
         for (let [event, datetime] of Object.entries(times)
-            .map( ([k,v]) => [k, moment(v)]) // wrap each datetime value in moment
             .sort( (a, b) => a[1].diff(b[1]) ) // Sort the sunevents into time order to make debugging easier
             ) {
             let millis = datetime.diff(now)

--- a/lib/sunevents.js
+++ b/lib/sunevents.js
@@ -90,7 +90,7 @@ class SunEvents extends EventEmitter {
 	    todayTimes[event] = datetime
         }
 
-        this.debug("Times are", util.inspect(times))
+        this.debug("Times are", util.inspect(todayTimes))
 
         return todayTimes
     }

--- a/test/suncalc-with-timezones-test.js
+++ b/test/suncalc-with-timezones-test.js
@@ -12,9 +12,9 @@ describe('suncalc', function() {
       times = suncalc.getTimes(date, 37.53, -122.26)
       dawn = moment(times.dawn)
       dusk = moment(times.dusk)
-      console.log(moment(date).format(), "Dawn:", dawn.format(), dawn.calendar(), "Dusk:", dusk.format(), dusk.calendar())
-      assert.equal(dawn.calendar(), 'Today at 6:17 AM')
-      assert.equal(dusk.calendar(), 'Today at 6:28 PM')
+      console.log(moment(date).format(), "Dawn:", dawn.format(), dawn.calendar(date), "Dusk:", dusk.format(), dusk.calendar(date))
+      assert.equal(dawn.calendar(date), 'Today at 6:17 AM')
+      assert.equal(dusk.calendar(date), 'Today at 6:28 PM')
       timezone_mock.unregister()
     });
 
@@ -26,8 +26,8 @@ describe('suncalc', function() {
             let times = suncalc.getTimes(date, 37.53, -122.26)
             let dawn = moment(times.dawn)
             let dusk = moment(times.dusk)
-            console.log("hour", i, date.format(), "Dawn:", dawn.format(), dawn.calendar(), "Dusk:", dusk.format(), dusk.calendar())
-            assert.equal(dawn.calendar(), 'Today at 6:17 AM', date.format())
+            console.log("hour", i, date.format(), "Dawn:", dawn.format(), dawn.calendar(date), "Dusk:", dusk.format(), dusk.calendar(date))
+            assert.equal(dawn.calendar(date), 'Today at 6:17 AM', date.format())
         }
         timezone_mock.unregister()
 
@@ -42,8 +42,8 @@ describe('suncalc', function() {
             let times = suncalc.getTimes(midday, 37.53, -122.26)
             let dawn = moment(times.dawn)
             let dusk = moment(times.dusk)
-            console.log("hour", i, date.format(), midday.format(), "Dawn:", dawn.format(), dawn.calendar(), "Dusk:", dusk.format(), dusk.calendar())
-            assert.equal(dawn.calendar(), 'Today at 6:17 AM', date.format())
+            console.log("hour", i, date.format(), midday.format(), "Dawn:", dawn.format(), dawn.calendar(date), "Dusk:", dusk.format(), dusk.calendar(date))
+            assert.equal(dawn.calendar(date), 'Today at 6:17 AM', date.format())
         }
         timezone_mock.unregister()
 

--- a/test/suncalc-with-timezones-test.js
+++ b/test/suncalc-with-timezones-test.js
@@ -49,5 +49,20 @@ describe('suncalc', function() {
 
     });
 
+    it('should return Yesterday nadir based on mid day for each hour Today', function() {
+        timezone_mock.register('US/Pacific')
+        let startdate = new Date('2020-11-30T00:30:00-08:00')
+        for (let i = 0; i < 24; i++) {
+            let date = moment(startdate).add(i, 'hour')
+            let midday = date.startOf('day').add(12, 'hours')
+            let times = suncalc.getTimes(midday, 37.53, -122.26)
+            let nadir = moment(times.nadir)
+            console.log("hour", i, date.format(), midday.format(), "Nadir:", nadir.format(), nadir.calendar(date))
+            assert.equal(nadir.calendar(date), 'Yesterday at 11:59 PM', date.format())
+        }
+        timezone_mock.unregister()
+
+    });
+
   });
 });

--- a/test/sunevents-test.js
+++ b/test/sunevents-test.js
@@ -1,11 +1,20 @@
 const timezone_mock = require('timezone-mock');
+const SunEvents = require('../lib/sunevents');
+const util = require('util');
+const moment = require('moment')
 
 var assert = require('assert');
 
 describe('sunevents', function() {
-  describe('#indexOf()', function() {
-    it('should return -1 when the value is not present', function() {
-      assert.equal([1, 2, 3].indexOf(4), -1);
+  describe('times with timezones', function() {
+    it('should return nadir for Today', function() {
+      timezone_mock.register('US/Pacific')
+      date = new Date('2020-11-30T06:00:00-08:00')
+      sunevent = new SunEvents(37.53, -122.26, {"debug": true, "testMode": true})
+      times = sunevent.getTimes(date, date)
+      nadir = moment(times.nadir)
+      assert.equal(nadir.calendar(date), 'Today at 11:59 PM')
+      timezone_mock.unregister()
     });
   });
 });


### PR DESCRIPTION
Hi,

Due to timezones and whatnot, suncalc.getTimes(today,...) will return events that happened yesterday and/or will happen tomorrow. I ran across this when my "nadir" events were never triggered after US/California in November.

This PR has:
1. fixes for the tests so that they use the test date as the reference for moment.calendar() calls so "Today" works.
2. refactors lib/sunevents to a) split out getTimes() for easier (for me), b) handle the case where events need to be pulled from "tomorrow"
3. adds a test to test the case above which passes now with point 2

Thanks for your consideration,

- Benjamin